### PR TITLE
Banker List Fix

### DIFF
--- a/predictor/templates/predictor/predict_amend.html
+++ b/predictor/templates/predictor/predict_amend.html
@@ -1,5 +1,5 @@
 {% extends "predictor/base.html" %}
-
+{% load predictor_custom_tags %}
 {% block content %}
 <script>
         $('#predict').each(function(){
@@ -45,16 +45,11 @@
         </div>
         <div class="divider hideme"></div>
         <div class = "section hideme" id="bankers">
-            <h5>Unavailable Bankers</h5>
-            <h6><em>(List excludes used bankers either on byes this week, or at home)</em></h6>
+            <h5>Used Bankers</h5>
             <ul>
-            {% for banker in bankers %}
-                {% for match in matches %}
-                    {% if match.AwayTeam == banker.BankerTeam %}
-                        <li id="{{ match.GameID }}"><img src="{{ banker.BankerTeam.Logo.url }}" alt="{{ banker.BankerTeam.Nickname }}" class="team_small"> {{ banker.BankerTeam }}</li>
-                    {% endif %}
+                {% for banker in bankers %}
+                    <li id="{{ banker.BankerTeam|corresponding_match }}"><img src="{{ banker.BankerTeam.Logo.url }}" alt="{{ banker.BankerTeam.Nickname }}" class="team_small"> {{ banker.BankerTeam }}</li>
                 {% endfor %}
-            {% endfor %}
             </ul>
         </div>
         <div id="submitted">

--- a/predictor/templates/predictor/predict_new.html
+++ b/predictor/templates/predictor/predict_new.html
@@ -1,5 +1,5 @@
 {% extends "predictor/base.html" %}
-
+{% load predictor_custom_tags %}
 {% block content %}
 <script>
         $('#predict').each(function(){
@@ -31,16 +31,11 @@
         </div>
         <div class="divider hideme"></div>
         <div class = "section hideme" id="bankers">
-            <h5>Unavailable Bankers</h5>
-            <h6><em>(List excludes used bankers either on byes this week, or at home)</em></h6>
+            <h5>Used Bankers</h5>
             <ul>
-            {% for banker in bankers %}
-                {% for match in matches %}
-                    {% if match.AwayTeam == banker.BankerTeam %}
-                        <li id="{{ match.GameID }}"><img src="{{ banker.BankerTeam.Logo.url }}" alt="{{ banker.BankerTeam.Nickname }}" class="team_small"> {{ banker.BankerTeam }}</li>
-                    {% endif %}
+                {% for banker in bankers %}
+                    <li id="{{ banker.BankerTeam|corresponding_match }}"><img src="{{ banker.BankerTeam.Logo.url }}" alt="{{ banker.BankerTeam.Nickname }}" class="team_small"> {{ banker.BankerTeam }}</li>
                 {% endfor %}
-            {% endfor %}
             </ul>
         </div>
         <div id="submitted">

--- a/predictor/templatetags/predictor_custom_tags.py
+++ b/predictor/templatetags/predictor_custom_tags.py
@@ -1,5 +1,7 @@
 from django import template
 from django.contrib.auth.models import Group
+from predictor.models import Match
+import os
 
 register = template.Library()
 
@@ -7,3 +9,19 @@ register = template.Library()
 def has_group(user, group_name):
     group = Group.objects.get(name=group_name)
     return True if group in user.groups.all() else False
+
+@register.filter(name='corresponding_match')
+def corresponding_match(bankerteam):
+    week = os.environ['PREDICTWEEK']
+    season = os.environ['PREDICTSEASON']
+    try:
+        matched_game = Match.objects.get(Season=season, Week=week, HomeTeam=bankerteam)
+    except Match.DoesNotExist:
+        try:
+            matched_game = Match.objects.get(Season=season, Week=week, AwayTeam=bankerteam)
+        except Match.DoesNotExist:
+            return 0
+        else:
+            return matched_game.GameID
+    else:
+        return matched_game.GameID


### PR DESCRIPTION
**Show All Bankers**

This update adds a custom template tag to allow the site to show all used bankers on the prediction pages.

Previously this was not possible because the Javascript looked for the GameID as the List Item's id parameter - that was fed through from the Match instance on the page and if a used Banker wasn't playing that week, they couldn't be listed.

The custom tag allows the site to iterate over a user's bankers and return the corresponding GameID for the week.  If no GameID is found (i.e. team is on a bye) then the custom tag returns 0.  This is fine because the Javascript determines duplicate bankers by checking if the chosen banker is in a list of bankers, which is read in from these list items.  0 will never match a GameID and so won't cause a conflict.