### PR TITLE
Table Alignment Fix

### DIFF
--- a/predictor/templates/predictor/scoretable.html
+++ b/predictor/templates/predictor/scoretable.html
@@ -40,11 +40,15 @@
                 <tr>
                     <td class="count"></td>
                     <td><img src="{{ seasonscore.User.FavouriteTeam.Logo.url }}" class="team_small"> &nbsp; {{ seasonscore.User.first_name }} {{ seasonscore.User.last_name }}</td>
-                    {% for weekscore in weekscores %}
-                        {% if seasonscore.User == weekscore.User %}
-                        <td>{{ weekscore.WeekScore }}</td>
-                        {% endif %}
-                    {% endfor %}
+                    {% if seasonscore.User in nopreds %}
+                        <td>Did Not Play</td>
+                    {% else %}
+                        {% for weekscore in weekscores %}
+                            {% if seasonscore.User == weekscore.User %}
+                            <td>{{ weekscore.WeekScore }}</td>
+                            {% endif %}
+                        {% endfor %}
+                    {% endif %}
                     <td>{{ seasonscore.SeasonScore }}</td>
                 </tr>
         {% endfor %}

--- a/predictor/views.py
+++ b/predictor/views.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.http import HttpResponse, JsonResponse
 from django.contrib.auth.models import User
+from accounts.models import User as CustomUser
 from django.contrib.auth.decorators import login_required, user_passes_test
 from .models import (
     Results,
@@ -178,10 +179,13 @@ def ScoreTableView(request):
     # Below sets score week to 1 below current results week
     # IE - to pull scores from last completed week 
     scoreweek = int(os.environ['RESULTSWEEK']) - 1
-    
+    weekscores = ScoresWeek.objects.filter(Week=scoreweek,Season=os.environ['PREDICTSEASON'])   
+    nopreds = CustomUser.objects.all().exclude(id__in=weekscores.values('User'))
+
     context = {
+        'nopreds': nopreds,
         'seasonscores': ScoresSeason.objects.filter(Season=os.environ['PREDICTSEASON']),
-        'weekscores': ScoresWeek.objects.filter(Week=scoreweek,Season=os.environ['PREDICTSEASON']),
+        'weekscores': weekscores,
         'week':scoreweek,
         'season':os.environ['PREDICTSEASON'],
         'title':'Leaderboard'


### PR DESCRIPTION
This pull request fixes #13, an issue whereby ScoreTable alignment was broken if a user did not place any predictions for the previous week.

To address this, we pass a queryset to the template which is initially populated by all user objects, but then excludes users whose ID is present in the queryset for weekly scores.

If the seasonscore user is in that queryset, then some text is displayed in the table column for weekly score.