### PR TITLE
Add logic for Results if user did not play

### DIFF
--- a/predictor/static/predictor/css/pigskin.css
+++ b/predictor/static/predictor/css/pigskin.css
@@ -159,6 +159,10 @@ table.results-table tbody tr td {
     font-weight: 600;
 }
 
+.results-table-dnp{
+    color: #01579B;
+}
+
 .results-table-total{
     font-weight: 700;
 }
@@ -183,4 +187,9 @@ table#stats-table tbody tr td {
     padding-top: 10px !important;
     padding-bottom: 10px !important;
     padding-left: 0px;
+}
+
+.throwaway {
+    font-weight: lighter;
+    font-style: oblique;
 }

--- a/predictor/templates/predictor/results-didnotplay.html
+++ b/predictor/templates/predictor/results-didnotplay.html
@@ -1,0 +1,40 @@
+{% extends "predictor/base.html" %}
+{% load predictor_custom_tags %}
+{% block content %}
+<script>
+    $('#results').each(function(){
+           $(this).toggleClass('active');
+       });
+</script>
+
+<div class="container">
+    <div class="row">
+        <div class="col m2"></div>
+        <div id="resultstable" class="col s12 m8">
+            <h5 class="mb-3">My Results</h5>
+            <h6>Looks like you didn't play in week {{ week }}
+            </h6>
+            <span class="throwaway">Nevermind; here are the results anyway</span>
+            <table class="striped responsive-table results-table">
+                <thead>
+                    <tr class="results-table-row">
+                        <th>Road Team</th>
+                        <th>Score</th>
+                        <th>Home Team</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for result in results %}
+                    <tr class="results-table-row">
+                            <td class="results-table-dnp"><img style="vertical-align:middle" src="{{ result.AwayTeam.Logo.url }}" class="team_small" alt="{{ result.AwayTeam }}">&nbsp; {{ result.AwayTeam.Nickname }}</td>
+                            <td class="results-table-dnp">{{ result.AwayScore }} - {{ result.HomeScore }}</td>
+                            <td class="results-table-dnp"><img style="vertical-align:middle" src="{{ result.HomeTeam.Logo.url }}" class="team_small" alt="{{ result.HomeTeam }}">&nbsp; {{ result.HomeTeam.Nickname }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <div class="col m2"></div>
+    </div>
+</div>
+{% endblock content %}

--- a/predictor/urls.py
+++ b/predictor/urls.py
@@ -4,6 +4,7 @@ from .views import (
     HomeView,
     ResultsView,
     ResultsPreSeasonView,
+    ResultsDidNotPlayView,
     ScheduleView,
     CreatePredictionsView, #New Predictions
     AmendPredictionsView, #Amend Predictions
@@ -29,6 +30,7 @@ urlpatterns = [
     path('profile',ProfileView,name="profile"),
     path('profile-amended', ProfileAmendedView,name="profile-amended"),
     path('results/', ResultsView, name='results'),
+    path('results-didnotplay/', ResultsDidNotPlayView, name='results-didnotplay'),
     path('results-preseason', ResultsPreSeasonView, name='results-preseason'),
     path('schedule/', ScheduleView.as_view(), name='schedule-view'), #!!!To Implement!!!
     path('predict/', CreatePredictionsView, name='new-prediction-view'), #New Predictions

--- a/predictor/views.py
+++ b/predictor/views.py
@@ -97,13 +97,32 @@ def ResultsView(request):
         scoreweek = 17
     else:
         scoreweek = basescoreweek
-    template = 'predictor/results.html' # <app>/<model>_viewtype>.html
+    template = 'predictor/results.html'
     PredWeek = int(str(os.environ['PREDICTSEASON'])+str(scoreweek))
-    context = {
+    if (Prediction.objects.filter(User=request.user, PredWeek=PredWeek)).count() == 0:
+        return redirect('results-didnotplay')   
+    else:
+        context = {
         'season': os.environ['PREDICTSEASON'],
         'week':scoreweek,
         'weekscore': ScoresWeek.objects.get(User=request.user, Season=os.environ['PREDICTSEASON'], Week=scoreweek).WeekScore,
         'predictions':Prediction.objects.filter(User=request.user, PredWeek=PredWeek),
+        'results':Results.objects.filter(Season=os.environ['PREDICTSEASON'], Week=scoreweek)
+        }
+        return render(request, template, context)
+
+def ResultsDidNotPlayView(request):
+    basescoreweek = int(os.environ['RESULTSWEEK']) - 1
+    if basescoreweek < 1:
+        return redirect('results-preseason')
+    elif basescoreweek > 17:
+        scoreweek = 17
+    else:
+        scoreweek = basescoreweek
+    template = 'predictor/results-didnotplay.html'
+    context = {
+        'season': os.environ['PREDICTSEASON'],
+        'week':scoreweek,
         'results':Results.objects.filter(Season=os.environ['PREDICTSEASON'], Week=scoreweek)
     }
     return render(request, template, context)


### PR DESCRIPTION
This update fixes an issue with the Results page if the user is logged in, but did not play in the previous week.  Previous an error would have been displayed as no matching predictions would have been found.  That error is now handled and the user is redirected to a page showing the game results without their corresponding predictions and resulting scores.