### PR TITLE
Profile Page Fixes

### DIFF
--- a/predictor/templates/predictor/profile-newplayer.html
+++ b/predictor/templates/predictor/profile-newplayer.html
@@ -1,0 +1,30 @@
+{% extends "predictor/base.html" %}
+{% load material_form %}
+{% block content %}
+<script>
+ $('#profile').each(function(){
+        $(this).toggleClass('active');
+    });
+</script>
+<div class='container'>
+    <div class="row">
+        <div class="col s12 m12">
+            <h5>Edit my Profile</h5>
+            <div class="divider"></div>
+            <div><br></div>
+            <form method="post">
+            {% csrf_token %}
+            {% form form=form %}
+            {% part form.first_name prefix %}<i class="material-icons prefix">face</i>{% endpart %}
+            {% part form.last_name prefix %}<i class="material-icons prefix">face</i>{% endpart %}
+            {% part form.FavouriteTeam prefix %}<i class="material-icons prefix">sports_football</i>{% endpart %}
+            {% endform %}
+            <br>
+            <button type="submit" style="float: right" class="btn waves-effect waves-light">update</button>
+            </form>
+            <br><br>
+            <span class="right-float"><i class="material-icons prefix pw-reset-icon">lock_open</i><a class="reset" href="/accounts/password/reset">RESET PASSWORD</a></span>
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/predictor/urls.py
+++ b/predictor/urls.py
@@ -20,6 +20,7 @@ from .views import (
     NewYearView, #AfterWeek17
     ProfileView,
     ProfileAmendedView,
+    ProfileNewPlayerView,
     RobotsTXT,
 )
 from . import views
@@ -29,6 +30,7 @@ urlpatterns = [
     path('robots.txt', RobotsTXT),
     path('profile',ProfileView,name="profile"),
     path('profile-amended', ProfileAmendedView,name="profile-amended"),
+    path('profile-newplayer', ProfileNewPlayerView,name="profile-newplayer"),
     path('results/', ResultsView, name='results'),
     path('results-didnotplay/', ResultsDidNotPlayView, name='results-didnotplay'),
     path('results-preseason', ResultsPreSeasonView, name='results-preseason'),

--- a/predictor/views.py
+++ b/predictor/views.py
@@ -65,25 +65,39 @@ def ProfileView(request):
             form.save()
             return redirect('profile-amended')
     else:
-        form = CustomUserChangeForm(instance=request.user)
-        template = "predictor/profile.html"
-        seasonhigh = ScoresSeason.objects.get(User=request.user, Season=(os.environ['PREDICTSEASON'])).SeasonBest
-        seasonlow = ScoresSeason.objects.get(User=request.user, Season=(os.environ['PREDICTSEASON'])).SeasonWorst
-        seasonpct = ScoresSeason.objects.get(User=request.user, Season=(os.environ['PREDICTSEASON'])).SeasonPercentage
-        alltimehigh = ScoresAllTime.objects.get(User=request.user).AllTimeBest
-        alltimelow = ScoresAllTime.objects.get(User=request.user).AllTimeWorst
-        alltimepct = ScoresAllTime.objects.get(User=request.user).AllTimePercentage
-        context = {
-            'form': form,
-            'season': (os.environ['PREDICTSEASON']),
-            'seasonhigh': seasonhigh,
-            'seasonlow': seasonlow,
-            'seasonpct': seasonpct,
-            'alltimehigh': alltimehigh,
-            'alltimelow': alltimelow,
-            'alltimepct': alltimepct,
-            }
-        return render(request, template, context)
+        try:
+            ScoresAllTime.objects.get(User=request.user)
+        except ScoresAllTime.DoesNotExist:
+            return redirect('profile-newplayer')
+        else:
+            # if week one, show best from last season
+            if int(os.environ['PREDICTWEEK']) == 1:
+                profileseason = str((int(os.environ['PREDICTSEASON'])) -1)
+            else:
+                profileseason = os.environ['PREDICTSEASON']
+            form = CustomUserChangeForm(instance=request.user)
+            template = "predictor/profile.html"
+            seasonhigh = ScoresSeason.objects.get(User=request.user, Season=profileseason).SeasonBest
+            seasonlow = ScoresSeason.objects.get(User=request.user, Season=profileseason).SeasonWorst
+            seasonpct = ScoresSeason.objects.get(User=request.user, Season=profileseason).SeasonPercentage
+            alltimehigh = ScoresAllTime.objects.get(User=request.user).AllTimeBest
+            alltimelow = ScoresAllTime.objects.get(User=request.user).AllTimeWorst
+            alltimepct = ScoresAllTime.objects.get(User=request.user).AllTimePercentage
+            context = {
+                'form': form,
+                'season': profileseason,
+                'seasonhigh': seasonhigh,
+                'seasonlow': seasonlow,
+                'seasonpct': seasonpct,
+                'alltimehigh': alltimehigh,
+                'alltimelow': alltimelow,
+                'alltimepct': alltimepct,
+                }
+            return render(request, template, context)
+
+def ProfileNewPlayerView(request):
+    form = CustomUserChangeForm(instance=request.user)
+    return render(request, 'predictor/profile-newplayer.html', {'form': form})
 
 def ProfileAmendedView(request):
     return render(request, 'predictor/profile-amended.html')


### PR DESCRIPTION
This update fixes two issues with the Profile: -

Firstly, for new players, it previously would have errored because they would have had no best scores to show.  Now it just shows a screen for players to amend their name and favourite team.

Secondly, if it is week 1, the page would have errored when trying to get the user's statistics for that season (there would be none at week 1).  In this instance, it now shows statistics for the preceding year.  If a player meets the first criteria above (they have _some_ scores) then they must have them for the previous year.