### PR TITLE
Rearranged Fixtures Fix

### DIFF
--- a/predictor/templates/predictor/predict_amend.html
+++ b/predictor/templates/predictor/predict_amend.html
@@ -33,12 +33,14 @@
                                             {% endif %}
                                         {% elif winner == 'Home' %}
                                             <img class="responsive-img hoverable team" src="{{ match.AwayTeam.Logo.url }}" id="Away" alt="{{ match.AwayTeam }}">  <img class="responsive-img hoverable team chosenwinner" src="{{ match.HomeTeam.Logo.url }}" id="Home" alt="{{ match.HomeTeam }}">
-                                        {% else %}
-                                            <img class="responsive-img hoverable team" src="{{ match.AwayTeam.Logo.url }}" id="Away" alt="{{ match.AwayTeam }}">  <img class="responsive-img hoverable team" src="{{ match.HomeTeam.Logo.url }}" id="Home" alt="{{ match.HomeTeam }}">
                                         {% endif %}
                                     {% endif %}
                                 {% endfor %}
-
+                                {% for game in notpredicted %}
+                                    {% if match.GameID == game.GameID %}
+                                        <img class="responsive-img hoverable team" src="{{ match.AwayTeam.Logo.url }}" id="Away" alt="{{ match.AwayTeam }}">  <img class="responsive-img hoverable team" src="{{ match.HomeTeam.Logo.url }}" id="Home" alt="{{ match.HomeTeam }}">
+                                    {% endif %}
+                                {% endfor %}
                             </div>
                         </div>
                     </div>

--- a/predictor/templates/predictor/predict_amend.html
+++ b/predictor/templates/predictor/predict_amend.html
@@ -33,6 +33,8 @@
                                             {% endif %}
                                         {% elif winner == 'Home' %}
                                             <img class="responsive-img hoverable team" src="{{ match.AwayTeam.Logo.url }}" id="Away" alt="{{ match.AwayTeam }}">  <img class="responsive-img hoverable team chosenwinner" src="{{ match.HomeTeam.Logo.url }}" id="Home" alt="{{ match.HomeTeam }}">
+                                        {% else %}
+                                            <img class="responsive-img hoverable team" src="{{ match.AwayTeam.Logo.url }}" id="Away" alt="{{ match.AwayTeam }}">  <img class="responsive-img hoverable team" src="{{ match.HomeTeam.Logo.url }}" id="Home" alt="{{ match.HomeTeam }}">
                                         {% endif %}
                                     {% endif %}
                                 {% endfor %}

--- a/predictor/views.py
+++ b/predictor/views.py
@@ -482,8 +482,12 @@ def AjaxAmendPredictionView(request):
             pred_game = Match.objects.get(GameID=pred_game_str)
             response_data = {}
 
-            oldprediction = Prediction.objects.get(User=pred_user, Game=pred_game)
-            oldprediction.delete()
+            try:
+                oldprediction = Prediction.objects.get(User=pred_user, Game=pred_game)
+            except Prediction.DoesNotExist:
+                pass
+            else:
+                oldprediction.delete()
         
             predictionentry = Prediction(User=pred_user, Game=pred_game, Winner=pred_winner)
             predictionentry.save()

--- a/predictor/views.py
+++ b/predictor/views.py
@@ -234,8 +234,13 @@ def AmendPredictionsView(request):
     week = os.environ['PREDICTWEEK']
     season = os.environ['PREDICTSEASON']
     UserPreds = Prediction.objects.filter(Game__Week=week, Game__Season=season, User=request.user)
+    Unpredicted = []
+    for i in UserPreds:
+        Unpredicted.append(i.Game.GameID)
     UserBankers = Banker.objects.filter(User=request.user, BankSeason=season)
     UserBankersAmend = UserBankers.exclude(BankWeek=week)
+    Matches = Match.objects.filter(Week=week, Season=season)
+    NotPredicted = Matches.exclude(GameID__in=Unpredicted)
     ClassDict = {}
     for preds in UserPreds:
         ClassDict[preds.Game.GameID] = preds.Winner
@@ -248,10 +253,11 @@ def AmendPredictionsView(request):
         'bankers':UserBankersAmend,
         'predictions':Prediction.objects.all(),
         'originalbanker':Banker.objects.get(BankWeek=week, BankSeason=season, User=request.user),
-        'matches':Match.objects.filter(Week=week, Season=season),
+        'matches':Matches,
         'week':week,
         'season':season,
-        'title':'Amend Predictions'
+        'title':'Amend Predictions',
+        'notpredicted': NotPredicted,
     }
 
     return render(request, template, context)


### PR DESCRIPTION
This fix resolves issue #45 

The template now renders correctly and the backend handles errors when trying to remove an old prediction that hasn't been made yet.