### PR TITLE
PredWeek value fix for APIs upon reschedule

### DIFF
--- a/predictor/views.py
+++ b/predictor/views.py
@@ -482,8 +482,12 @@ def AjaxAmendPredictionView(request):
             pred_game = Match.objects.get(GameID=pred_game_str)
             response_data = {}
 
-            oldprediction = Prediction.objects.get(User=pred_user, Game=pred_game)
-            oldprediction.delete()
+            try:
+                oldprediction = Prediction.objects.get(User=pred_user, Game=pred_game)
+            except Prediction.DoesNotExist:
+                pass
+            else:
+                oldprediction.delete()
         
             predictionentry = Prediction(User=pred_user, Game=pred_game, Winner=pred_winner)
             predictionentry.save()


### PR DESCRIPTION
**This PR fixes issue #48**

- A function has been added to the Match class which is called after a save.  The function finds matching Prediction entries and amends the PredWeek value to the new value.