### PR TITLE
Initial branch commit with new scripts

### DIFF
--- a/predictor/scripts/movepoints_post9.py
+++ b/predictor/scripts/movepoints_post9.py
@@ -1,0 +1,28 @@
+## Script to Move points from a game back one week
+## Occasionally needed for Covid rescheduled games
+## This version only to be run AFTER the ResultsWeek env var has rolled over
+
+from predictor.models import ScoresWeek, Prediction, Match
+import os
+
+def run(*args):
+    week = int(os.environ['RESULTSWEEK'])-1
+    season = int(os.environ['PREDICTSEASON'])
+    for gameid in args:
+        match = Match.objects.get(GameID=int(gameid))
+        preds = Prediction.objects.filter(Game=match)
+        for pred in preds:
+            try:
+                thisweek = ScoresWeek.objects.get(Season=season, Week=week, User=pred.User)
+            except:
+                pass
+            else:
+                thisweek.WeekScore = thisweek.WeekScore - pred.Points
+                thisweek.save()
+            try:
+                lastweek = ScoresWeek.objects.get(Season=season, Week=(week-1), User=pred.User)
+            except:
+                pass
+            else:
+                lastweek.WeekScore = lastweek.WeekScore + pred.Points
+                lastweek.save()

--- a/predictor/scripts/movepoints_pre9.py
+++ b/predictor/scripts/movepoints_pre9.py
@@ -1,0 +1,28 @@
+## Script to Move points from a game back one week
+## Occasionally needed for Covid rescheduled games
+## This version only to be run BEFORE the ResultsWeek env var has rolled over
+
+from predictor.models import ScoresWeek, Prediction, Match
+import os
+
+def run(*args):
+    week = int(os.environ['RESULTSWEEK'])
+    season = int(os.environ['PREDICTSEASON'])
+    for gameid in args:
+        match = Match.objects.get(GameID=int(gameid))
+        preds = Prediction.objects.filter(Game=match)
+        for pred in preds:
+            try:
+                thisweek = ScoresWeek.objects.get(Season=season, Week=week, User=pred.User)
+            except:
+                pass
+            else:
+                thisweek.WeekScore = thisweek.WeekScore - pred.Points
+                thisweek.save()
+            try:
+                lastweek = ScoresWeek.objects.get(Season=season, Week=(week-1), User=pred.User)
+            except:
+                pass
+            else:
+                lastweek.WeekScore = lastweek.WeekScore + pred.Points
+                lastweek.save()


### PR DESCRIPTION
**Points Move Scripts Added**

This PR adds some quick scripts that will amend weekly score totals for a particular match if game administrators have held it back a week.  An example of such is DEN @ NE in week 6 of the 2020 season.  This was kept as a week 5 game, to avoid players not playing a banker in week 5/inadvertanly playing two bankers in week 6.

The result for the above example would then be fetched and scored at the end of week 6 but the points for that game would need moving from the ScoresWeek entry from week 6 to week 5, for consistency.  Otherwise, some players could benefit from an inflated weekly score by way of playing two bankers.