### PR TITLE
Redis cache

### DIFF
--- a/djangosite01/settings.py
+++ b/djangosite01/settings.py
@@ -203,3 +203,14 @@ REST_FRAMEWORK = {
 CELERY_BROKER_URL = os.environ.get('REDIS_URL')
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": os.environ.get('REDIS_URL')+"/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+        "KEY_PREFIX": "pigskindjango"
+    }
+}

--- a/djangosite01/settings.py
+++ b/djangosite01/settings.py
@@ -212,6 +212,5 @@ CACHES = {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
         "KEY_PREFIX": "pigskindjango",
-        "TIMEOUT": 60 * 60 * 24 * 7 # Items in the cache will expire after 1 week
     }
 }

--- a/djangosite01/settings.py
+++ b/djangosite01/settings.py
@@ -211,6 +211,7 @@ CACHES = {
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
-        "KEY_PREFIX": "pigskindjango"
+        "KEY_PREFIX": "pigskindjango",
+        "TIMEOUT": 60 * 60 * 24 * 7 # Items in the cache will expire after 1 week
     }
 }

--- a/predictor/scripts/cacheflushlist.py
+++ b/predictor/scripts/cacheflushlist.py
@@ -1,0 +1,7 @@
+cachestoflush = [
+         "NFC West_Players", "NFC East_Players", "NFC North_Players", "NFC South_Players",
+         "AFC West_Players", "AFC East_Players", "AFC North_Players", "AFC South_Players", 
+         "NFC West_Total", "NFC East_Total", "NFC North_Total", "NFC South_Total",
+         "AFC West_Total", "AFC East_Total", "AFC North_Total", "AFC South_Total",
+         "jsonseasonscorescache", "jsonweekscorescache", "DivAvgDict"
+         ]

--- a/predictor/scripts/saveresults_adhoc.py
+++ b/predictor/scripts/saveresults_adhoc.py
@@ -4,6 +4,8 @@
 
 import os, json, boto3
 from predictor.models import Team, Results, ScoresSeason, ScoresAllTime, ScoresWeek, Prediction
+from django.core.cache import cache
+from .cacheflushlist import cachestoflush
 
 def run():
    resultsweek = os.environ['RESULTSWEEK']
@@ -88,3 +90,5 @@ def run():
                alltimebanktotal += alltimebanker.Points
          alltime.AllTimeBankerAverage=alltimebanktotal/Prediction.objects.filter(User=alltime.User, Banker=True).exclude(Points__isnull=True).count()
          alltime.save()
+   for c in cachestoflush:
+      cache.delete(c)

--- a/predictor/scripts/saveresults_thurs.py
+++ b/predictor/scripts/saveresults_thurs.py
@@ -5,6 +5,8 @@
 
 import os, json, boto3, datetime
 from predictor.models import Team, Results, ScoresSeason, ScoresAllTime, ScoresWeek, Prediction
+from django.core.cache import cache
+from .cacheflushlist import cachestoflush
 
 def run():
    # Loop to ensure script only executes on a Thursday!
@@ -90,5 +92,7 @@ def run():
                   alltimebanktotal += alltimebanker.Points
             alltime.AllTimeBankerAverage=alltimebanktotal/Prediction.objects.filter(User=alltime.User, Banker=True).exclude(Points__isnull=True).count()
             alltime.save()
+      for c in cachestoflush:
+            cache.delete(c)
    else:
       pass

--- a/predictor/scripts/saveresults_tues.py
+++ b/predictor/scripts/saveresults_tues.py
@@ -5,6 +5,8 @@
 
 import os, json, boto3, datetime
 from predictor.models import Team, Results, ScoresSeason, ScoresAllTime, ScoresWeek, Prediction
+from django.core.cache import cache
+from .cacheflushlist import cachestoflush
 
 def run():
    # Loop to ensure script only executes on a Tuesday!
@@ -89,6 +91,8 @@ def run():
                if isinstance(alltimebanker.Points, int):
                   alltimebanktotal += alltimebanker.Points
             alltime.AllTimeBankerAverage=alltimebanktotal/Prediction.objects.filter(User=alltime.User, Banker=True).exclude(Points__isnull=True).count()
-            alltime.save()
+            alltime.save()        
+      for c in cachestoflush:
+         cache.delete(c)
    else:
       pass

--- a/predictor/scripts/saveresults_weds.py
+++ b/predictor/scripts/saveresults_weds.py
@@ -5,6 +5,8 @@
 
 import os, json, boto3, datetime
 from predictor.models import Team, Results, ScoresSeason, ScoresAllTime, ScoresWeek, Prediction
+from django.core.cache import cache
+from .cacheflushlist import cachestoflush
 
 def run():
    # Loop to ensure script only executes on a Wednesday!
@@ -90,5 +92,7 @@ def run():
                   alltimebanktotal += alltimebanker.Points
             alltime.AllTimeBankerAverage=alltimebanktotal/Prediction.objects.filter(User=alltime.User, Banker=True).exclude(Points__isnull=True).count()
             alltime.save()
+      for c in cachestoflush:
+         cache.delete(c)
    else:
       pass

--- a/predictor/templates/predictor/base.html
+++ b/predictor/templates/predictor/base.html
@@ -1,7 +1,9 @@
 {% load static %}
+{% load cache %}
 {% load predictor_custom_tags %}
 {% include 'material/includes/material_css.html' %}
 {% include 'material/includes/material_js.html' %}
+{% cache 600 header request.user.username %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -79,8 +81,10 @@
       </ul>
       </header>
       <main>
+      {% endcache %}
       {% block content %}
       {% endblock %}
+      {% cache 600 footer request.user.username %}
       <p></p>
       </main>
       <footer class="page-footer footer-pigskin">
@@ -109,3 +113,4 @@
     {% endblock javascript %}
   </body>
 </html>
+{% endcache %}

--- a/predictor/templatetags/predictor_custom_tags.py
+++ b/predictor/templatetags/predictor_custom_tags.py
@@ -43,7 +43,7 @@ def corresponding_away(predgameid):
 
 @register.filter(name='division_players')
 def division_players(div):
-    cachename=div+'_players'
+    cachename=div+'_Players'
     players = cache.get(cachename)
     if not players:
         division = Team.objects.filter(ConfDiv=div)
@@ -58,7 +58,7 @@ def division_players(div):
 
 @register.filter(name='division_total')
 def division_total(div):
-    cachename=div+'_total'
+    cachename=div+'_Total'
     total = cache.get(cachename)
     if not total:
         division = Team.objects.filter(ConfDiv=div)

--- a/predictor/templatetags/predictor_custom_tags.py
+++ b/predictor/templatetags/predictor_custom_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.core.cache import cache
 from django.contrib.auth.models import Group
 from predictor.models import Match, ScoresWeek, Results, Team, ScoresSeason, Prediction
 from accounts.models import User
@@ -42,27 +43,37 @@ def corresponding_away(predgameid):
 
 @register.filter(name='division_players')
 def division_players(div):
-    division = Team.objects.filter(ConfDiv=div)
-    try:
-        players = User.objects.filter(FavouriteTeam__in=division).count()
-    except:
-        return 0
-    else:
-        return players
+    cachename=div+'_players'
+    players = cache.get(cachename)
+    if not players:
+        division = Team.objects.filter(ConfDiv=div)
+        try:
+            players = User.objects.filter(FavouriteTeam__in=division).count()
+        except:
+            players = 0
+            cache.set(cachename, 0)
+        else:
+            cache.set(cachename, players)
+    return players
 
 @register.filter(name='division_total')
 def division_total(div):
-    division = Team.objects.filter(ConfDiv=div)
-    try:
-        players = User.objects.filter(FavouriteTeam__in=division)
-    except:
-        return 0
-    total = 0
-    for player in players:
+    cachename=div+'_total'
+    total = cache.get(cachename)
+    if not total:
+        division = Team.objects.filter(ConfDiv=div)
         try:
-            total += ScoresSeason.objects.get(User=player, Season=int(os.environ['PREDICTSEASON'])).SeasonScore
+            players = User.objects.filter(FavouriteTeam__in=division)
         except:
-            pass
+            cache.set(cachename, 0)
+            total = 0
+        total = 0
+        for player in players:
+            try:
+                total += ScoresSeason.objects.get(User=player, Season=int(os.environ['PREDICTSEASON'])).SeasonScore
+            except:
+                pass
+        cache.set(cachename, total)
     return total
 
 @register.filter(name='banker_class')

--- a/predictor/views.py
+++ b/predictor/views.py
@@ -1,4 +1,5 @@
 import json, os
+from django.core.cache import cache
 from .helpers import get_json_week_score
 from django.shortcuts import render, get_object_or_404, redirect
 from accounts.forms import CustomUserChangeForm
@@ -662,164 +663,171 @@ def DivisionTableView(request):
         userdivision = request.user.FavouriteTeam.ConfDiv
     except:
         userdivision = 'None'
-    NFCN = Team.objects.filter(ConfDiv='NFC North')
-    NFCS = Team.objects.filter(ConfDiv='NFC South')
-    NFCW = Team.objects.filter(ConfDiv='NFC West')
-    NFCE = Team.objects.filter(ConfDiv='NFC East')
-    AFCN = Team.objects.filter(ConfDiv='AFC North')
-    AFCS = Team.objects.filter(ConfDiv='AFC South')
-    AFCW = Team.objects.filter(ConfDiv='AFC West')
-    AFCE = Team.objects.filter(ConfDiv='AFC East')
-    try:
-        NFCNfans = CustomUser.objects.filter(FavouriteTeam__in=NFCN)
-    except:
-        NFCNcount = 0
-        NFCNfans = []
-    else:
-        NFCNcount = NFCNfans.count()
-    try:
-        NFCSfans = CustomUser.objects.filter(FavouriteTeam__in=NFCS)
-    except:
-        NFCScount = 0
-        NFCSfans = []
-    else:
-        NFCScount = NFCSfans.count()
-    try:
-        NFCWfans = CustomUser.objects.filter(FavouriteTeam__in=NFCW)
-    except:
-        NFCWcount = 0
-        NFCWfans = []
-    else:
-        NFCWcount = NFCWfans.count()
-    try:
-        NFCEfans = CustomUser.objects.filter(FavouriteTeam__in=NFCE)
-    except:
-        NFCEcount = 0
-        NFCEfans = []
-    else:
-        NFCEcount = NFCEfans.count()
-    try:
-        AFCNfans = CustomUser.objects.filter(FavouriteTeam__in=AFCN)
-    except:
-        AFCNcount = 0
-        AFCNfans = []
-    else:
-        AFCNcount = AFCNfans.count()
-    try:
-        AFCSfans = CustomUser.objects.filter(FavouriteTeam__in=AFCS)
-    except:
-        AFCScount = 0
-        AFCSfans = []
-    else:
-        AFCScount = AFCSfans.count()
-    try:
-        AFCWfans = CustomUser.objects.filter(FavouriteTeam__in=AFCW)
-    except:
-        AFCWcount = 0
-        AFCWfans = []
-    else:
-        AFCWcount = AFCWfans.count()
-    try:
-        AFCEfans = CustomUser.objects.filter(FavouriteTeam__in=AFCE)
-    except:
-        AFCEcount = 0
-        AFCEfans = []
-    else:
-        AFCEcount = AFCEfans.count()
-    NFCNTotal = 0
-    NFCSTotal = 0
-    NFCETotal = 0
-    NFCWTotal = 0
-    AFCNTotal = 0
-    AFCSTotal = 0
-    AFCETotal = 0
-    AFCWTotal = 0
-    for fan in NFCNfans:
-        try:
-            NFCNTotal += ScoresSeason.objects.get(Season=int(os.environ['PREDICTSEASON']), User=fan).SeasonScore
-        except ScoresSeason.DoesNotExist:
-            pass
-    try:
-        NFCNAvg = int(NFCNTotal/NFCNcount)
-    except ZeroDivisionError:
-        NFCNAvg = 0
 
-    for fan in NFCSfans:
-        try:
-            NFCSTotal += ScoresSeason.objects.get(User=fan).SeasonScore
-        except ScoresSeason.DoesNotExist:
-            pass
-    try:
-        NFCSAvg = int(NFCSTotal/NFCScount)
-    except ZeroDivisionError:
-        NFCSAvg = 0
-    
-    for fan in NFCEfans:
-        try:
-            NFCETotal += ScoresSeason.objects.get(User=fan).SeasonScore
-        except ScoresSeason.DoesNotExist:
-            pass
-    try:
-        NFCEAvg = int(NFCETotal/NFCEcount)
-    except ZeroDivisionError:
-        NFCEAvg = 0
+    SortedList = cache.get('DivAvgDict')
 
-    for fan in NFCWfans:
+    if not SortedList:
+        NFCN = Team.objects.filter(ConfDiv='NFC North')
+        NFCS = Team.objects.filter(ConfDiv='NFC South')
+        NFCW = Team.objects.filter(ConfDiv='NFC West')
+        NFCE = Team.objects.filter(ConfDiv='NFC East')
+        AFCN = Team.objects.filter(ConfDiv='AFC North')
+        AFCS = Team.objects.filter(ConfDiv='AFC South')
+        AFCW = Team.objects.filter(ConfDiv='AFC West')
+        AFCE = Team.objects.filter(ConfDiv='AFC East')
         try:
-            NFCWTotal += ScoresSeason.objects.get(User=fan).SeasonScore
-        except ScoresSeason.DoesNotExist:
-            pass
-    try:
-        NFCWAvg = int(NFCWTotal/NFCWcount)
-    except ZeroDivisionError:
-        NFCWAvg = 0
-    
-    for fan in AFCNfans:
+            NFCNfans = CustomUser.objects.filter(FavouriteTeam__in=NFCN)
+        except:
+            NFCNcount = 0
+            NFCNfans = []
+        else:
+            NFCNcount = NFCNfans.count()
         try:
-            AFCNTotal += ScoresSeason.objects.get(User=fan).SeasonScore
-        except ScoresSeason.DoesNotExist:
-            pass
-    try:
-        AFCNAvg = int(AFCNTotal/AFCNcount)
-    except ZeroDivisionError:
-        AFCNAvg = 0
-    
-    for fan in AFCSfans:
+            NFCSfans = CustomUser.objects.filter(FavouriteTeam__in=NFCS)
+        except:
+            NFCScount = 0
+            NFCSfans = []
+        else:
+            NFCScount = NFCSfans.count()
         try:
-            AFCSTotal += ScoresSeason.objects.get(User=fan).SeasonScore
-        except ScoresSeason.DoesNotExist:
-            pass
-    try:
-        AFCSAvg = int(AFCSTotal/AFCScount)
-    except ZeroDivisionError:
-        AFCSAvg = 0
+            NFCWfans = CustomUser.objects.filter(FavouriteTeam__in=NFCW)
+        except:
+            NFCWcount = 0
+            NFCWfans = []
+        else:
+            NFCWcount = NFCWfans.count()
+        try:
+            NFCEfans = CustomUser.objects.filter(FavouriteTeam__in=NFCE)
+        except:
+            NFCEcount = 0
+            NFCEfans = []
+        else:
+            NFCEcount = NFCEfans.count()
+        try:
+            AFCNfans = CustomUser.objects.filter(FavouriteTeam__in=AFCN)
+        except:
+            AFCNcount = 0
+            AFCNfans = []
+        else:
+            AFCNcount = AFCNfans.count()
+        try:
+            AFCSfans = CustomUser.objects.filter(FavouriteTeam__in=AFCS)
+        except:
+            AFCScount = 0
+            AFCSfans = []
+        else:
+            AFCScount = AFCSfans.count()
+        try:
+            AFCWfans = CustomUser.objects.filter(FavouriteTeam__in=AFCW)
+        except:
+            AFCWcount = 0
+            AFCWfans = []
+        else:
+            AFCWcount = AFCWfans.count()
+        try:
+            AFCEfans = CustomUser.objects.filter(FavouriteTeam__in=AFCE)
+        except:
+            AFCEcount = 0
+            AFCEfans = []
+        else:
+            AFCEcount = AFCEfans.count()
+        NFCNTotal = 0
+        NFCSTotal = 0
+        NFCETotal = 0
+        NFCWTotal = 0
+        AFCNTotal = 0
+        AFCSTotal = 0
+        AFCETotal = 0
+        AFCWTotal = 0
+        for fan in NFCNfans:
+            try:
+                NFCNTotal += ScoresSeason.objects.get(Season=int(os.environ['PREDICTSEASON']), User=fan).SeasonScore
+            except ScoresSeason.DoesNotExist:
+                pass
+        try:
+            NFCNAvg = int(NFCNTotal/NFCNcount)
+        except ZeroDivisionError:
+            NFCNAvg = 0
 
-    for fan in AFCWfans:
+        for fan in NFCSfans:
+            try:
+                NFCSTotal += ScoresSeason.objects.get(User=fan).SeasonScore
+            except ScoresSeason.DoesNotExist:
+                pass
         try:
-            AFCWTotal += ScoresSeason.objects.get(User=fan).SeasonScore
-        except ScoresSeason.DoesNotExist:
-            pass
-    try:
-        AFCWAvg = int(AFCWTotal/AFCWcount)
-    except ZeroDivisionError:
-        AFCWAvg = 0
-
-    for fan in AFCEfans:
+            NFCSAvg = int(NFCSTotal/NFCScount)
+        except ZeroDivisionError:
+            NFCSAvg = 0
+        
+        for fan in NFCEfans:
+            try:
+                NFCETotal += ScoresSeason.objects.get(User=fan).SeasonScore
+            except ScoresSeason.DoesNotExist:
+                pass
         try:
-            AFCETotal += ScoresSeason.objects.get(User=fan).SeasonScore
-        except ScoresSeason.DoesNotExist:
-            pass
-    try:
-        AFCEAvg = int(AFCETotal/AFCEcount)
-    except ZeroDivisionError:
-        AFCEAvg = 0
+            NFCEAvg = int(NFCETotal/NFCEcount)
+        except ZeroDivisionError:
+            NFCEAvg = 0
 
-    RawDict = {'NFC North': NFCNAvg, 'NFC South': NFCSAvg,
-    'NFC East': NFCEAvg, 'NFC West': NFCWAvg, 'AFC North': AFCNAvg,
-    'AFC South': AFCSAvg, 'AFC East': AFCEAvg, 'AFC West': AFCWAvg,}
+        for fan in NFCWfans:
+            try:
+                NFCWTotal += ScoresSeason.objects.get(User=fan).SeasonScore
+            except ScoresSeason.DoesNotExist:
+                pass
+        try:
+            NFCWAvg = int(NFCWTotal/NFCWcount)
+        except ZeroDivisionError:
+            NFCWAvg = 0
+        
+        for fan in AFCNfans:
+            try:
+                AFCNTotal += ScoresSeason.objects.get(User=fan).SeasonScore
+            except ScoresSeason.DoesNotExist:
+                pass
+        try:
+            AFCNAvg = int(AFCNTotal/AFCNcount)
+        except ZeroDivisionError:
+            AFCNAvg = 0
+        
+        for fan in AFCSfans:
+            try:
+                AFCSTotal += ScoresSeason.objects.get(User=fan).SeasonScore
+            except ScoresSeason.DoesNotExist:
+                pass
+        try:
+            AFCSAvg = int(AFCSTotal/AFCScount)
+        except ZeroDivisionError:
+            AFCSAvg = 0
 
-    SortedDict = {k: v for k, v in sorted(RawDict.items(), key=lambda item: item[1],reverse=True)}
-    SortedList = list(SortedDict.items())
+        for fan in AFCWfans:
+            try:
+                AFCWTotal += ScoresSeason.objects.get(User=fan).SeasonScore
+            except ScoresSeason.DoesNotExist:
+                pass
+        try:
+            AFCWAvg = int(AFCWTotal/AFCWcount)
+        except ZeroDivisionError:
+            AFCWAvg = 0
+
+        for fan in AFCEfans:
+            try:
+                AFCETotal += ScoresSeason.objects.get(User=fan).SeasonScore
+            except ScoresSeason.DoesNotExist:
+                pass
+        try:
+            AFCEAvg = int(AFCETotal/AFCEcount)
+        except ZeroDivisionError:
+            AFCEAvg = 0
+
+        RawDict = {'NFC North': NFCNAvg, 'NFC South': NFCSAvg,
+        'NFC East': NFCEAvg, 'NFC West': NFCWAvg, 'AFC North': AFCNAvg,
+        'AFC South': AFCSAvg, 'AFC East': AFCEAvg, 'AFC West': AFCWAvg,}
+
+        SortedDict = {k: v for k, v in sorted(RawDict.items(), key=lambda item: item[1],reverse=True)}
+        SortedList = list(SortedDict.items())
+        print(type(SortedList))
+
+        cache.set('DivAvgDict', SortedList)
 
     context = {
         'scores': SortedList,

--- a/predictor/views.py
+++ b/predictor/views.py
@@ -518,23 +518,27 @@ def ScoreTableEnhancedView(request):
     weekscores = ScoresWeek.objects.filter(Week=scoreweek,Season=os.environ['PREDICTSEASON'])   
     nopreds = CustomUser.objects.all().exclude(id__in=weekscores.values('User'))
 
-    jsonseasonscores = {'season_scores' : [{
-        'pos': i+1,
-        'user': s.User.Full_Name,
-        'logo': s.User.FavouriteTeam.Logo.url,
-        'teamshort': s.User.FavouriteTeam.ShortName,
-        'week': get_json_week_score(s.User, scoreweek, os.environ['PREDICTSEASON']),
-        'seasonscore': s.SeasonScore,
-        'seasonworst': s.SeasonWorst,
-        'seasonbest': s.SeasonBest,
-        'seasoncorrect': s.SeasonCorrect,
-        'seasonpercentage': float(s.SeasonPercentage),
-        'seasonaverage': float(s.SeasonAverage),
-        'bankeraverage': float(s.BankerAverage),
+    jsonseasonscores = cache.get('jsonseasonscorescache')
+
+    if not jsonseasonscores:
+        jsonseasonscores = {'season_scores' : [{
+            'pos': i+1,
+            'user': s.User.Full_Name,
+            'logo': s.User.FavouriteTeam.Logo.url,
+            'teamshort': s.User.FavouriteTeam.ShortName,
+            'week': get_json_week_score(s.User, scoreweek, os.environ['PREDICTSEASON']),
+            'seasonscore': s.SeasonScore,
+            'seasonworst': s.SeasonWorst,
+            'seasonbest': s.SeasonBest,
+            'seasoncorrect': s.SeasonCorrect,
+            'seasonpercentage': float(s.SeasonPercentage),
+            'seasonaverage': float(s.SeasonAverage),
+            'bankeraverage': float(s.BankerAverage),
+            }
+            # enumerate needed to allow us to extract the index (position) using i,s
+            for i,s in enumerate(ScoresSeason.objects.filter(Season=os.environ['PREDICTSEASON']))]
         }
-        # enumerate needed to allow us to extract the index (position) using i,s
-        for i,s in enumerate(ScoresSeason.objects.filter(Season=os.environ['PREDICTSEASON']))]
-    }
+        cache.set('jsonseasonscorescache', jsonseasonscores)
 
     jsonweekscores = {'week_scores' : [{
         'user': s.User.Full_Name,


### PR DESCRIPTION
This PR implements redis caching (enhancement #90) for the following: -

Base page header and footer on a per user basis (as admins have extra links) (5 min TTL)
Advanced Scoretable Data
Divisional Scoretable Data

Cached scoretable data is set with a 1 week TTL.  Weekly results saving scripts will delete all of these caches after results are saved, meaning the data in cache should always be up to date.

This will result in much faster loading times for these pages which, by their nature, are heavy on database queries.