### PR TITLE
Fix for Issue #96

### DIFF
--- a/predictor/templates/predictor/scoretable_enhanced.html
+++ b/predictor/templates/predictor/scoretable_enhanced.html
@@ -26,6 +26,8 @@
 {{ jsonseasonscores|json_script:'seasonscores' }}
 {{ jsonweekscores|json_script:'weekscores' }}
 {{ jsonuser|json_script:'currentuser' }}
+{{ jsonurls|json_script:'logo_urls' }}
+
 <div class="container">
 <h5 class="mb-3">
     Leaderboards: <a href="{% url 'scoretable' %}" class = "big-link-inactive">Standard</a> <span class = "superlowlight">|</span> <span class = "big-link-active">Enhanced</span> <span class = "superlowlight">|</span> <a class = "big-link-inactive" href="{% url 'scoretable-division' %}">Division</a></h5>
@@ -46,11 +48,11 @@
                 </tr>
             </thead>
             <tbody>
-            <tr v-for="score in sortedTable">
+            <tr v-for="score in sortedTable" :key="score.pos">
                 <td v-if="score.user ===  currentUser" class = "table-highlight enhanced clamp pad-l">[[score.pos]] </td>
                 <td v-else td class="enhanced clamp pad-l">[[score.pos]] </td>
-                <td v-if="score.user ===  currentUser" class = "table-highlight enhanced clamp pad-l table-logo"><img v-bind:src=[[score.logo]] alt=[[score.teamshort]] class="team_small"></img></td>
-                <td v-else td class="enhanced clamp pad-l table-logo"><img v-bind:src=[[score.logo]] alt=[[score.teamshort]] class="team_small"></img></td>
+                <td v-if="score.user ===  currentUser" class = "table-highlight enhanced clamp pad-l table-logo"><img v-bind:src="score.teamshort | imgurl" :alt="score.teamshort" class="team_small"></img></td>
+                <td v-else td class="enhanced clamp pad-l table-logo"><img :src="score.teamshort | imgurl" :alt="score.teamshort" class="team_small"></img></td>
                 <td v-if="score.user ===  currentUser" class = "table-highlight enhanced clamp">[[score.user]]</td>
                 <td v-else class="enhanced clamp">[[score.user]]</td>
                 <td v-if="score.user ===  currentUser" class = "table-highlight enhanced clamp">[[score.week]]</td>
@@ -78,6 +80,7 @@
 let seasonScores = JSON.parse(document.getElementById('seasonscores').textContent).season_scores;
 let weekScores = JSON.parse(document.getElementById('weekscores').textContent).week_scores;
 let currentUser = JSON.parse(document.getElementById('currentuser').textContent).user;
+let logoUrls = JSON.parse(document.getElementById('logo_urls').textContent);
 
 // for loop to add weekScores to seasonScores for each user
 
@@ -88,6 +91,8 @@ let currentUser = JSON.parse(document.getElementById('currentuser').textContent)
         el: '#vue-table',
         data: {
             seasonScores,
+            logoUrls,
+            currentUser,
             weekScores,
             currentSort: 'pos',
             currentSortDir: 'asc',
@@ -208,7 +213,12 @@ let currentUser = JSON.parse(document.getElementById('currentuser').textContent)
                 return 0;
                 });
             }
-        }
+        },
+        filters:{
+            imgurl: function(team) {
+                return logoUrls[team]
+            }
+        },
     })
 </script>
 

--- a/predictor/templatetags/predictor_custom_tags.py
+++ b/predictor/templatetags/predictor_custom_tags.py
@@ -5,6 +5,12 @@ from predictor.models import Match, ScoresWeek, Results, Team, ScoresSeason, Pre
 from accounts.models import User
 import os
 
+CacheTTL_1Week = 60 * 60 * 24 * 7
+CacheTTL_1Day = 60 * 60 * 24
+CacheTTL_1Hour = 60 * 60
+CacheTTL_3Hours = 60 * 60 * 3
+CacheTTL_5Mins = 60 *5
+
 register = template.Library()
 
 @register.filter(name='has_group')
@@ -43,7 +49,7 @@ def corresponding_away(predgameid):
 
 @register.filter(name='division_players')
 def division_players(div):
-    cachename=div+'_Players'
+    cachename = div+'_Players'
     players = cache.get(cachename)
     if not players:
         division = Team.objects.filter(ConfDiv=div)
@@ -53,12 +59,12 @@ def division_players(div):
             players = 0
             cache.set(cachename, 0)
         else:
-            cache.set(cachename, players)
+            cache.set(cachename, players, CacheTTL_1Week)
     return players
 
 @register.filter(name='division_total')
 def division_total(div):
-    cachename=div+'_Total'
+    cachename = div+'_Total'
     total = cache.get(cachename)
     if not total:
         division = Team.objects.filter(ConfDiv=div)
@@ -73,7 +79,7 @@ def division_total(div):
                 total += ScoresSeason.objects.get(User=player, Season=int(os.environ['PREDICTSEASON'])).SeasonScore
             except:
                 pass
-        cache.set(cachename, total)
+        cache.set(cachename, total, CacheTTL_1Week)
     return total
 
 @register.filter(name='banker_class')

--- a/predictor/views.py
+++ b/predictor/views.py
@@ -39,6 +39,7 @@ CacheTTL_1Week = 60 * 60 * 24 * 7
 CacheTTL_1Day = 60 * 60 * 24
 CacheTTL_1Hour = 60 * 60
 CacheTTL_3Hours = 60 * 60 * 3
+CacheTTL_5Mins = 60 *5
 
 @require_GET
 def RobotsTXT(request):
@@ -529,7 +530,6 @@ def ScoreTableEnhancedView(request):
         jsonseasonscores = {'season_scores' : [{
             'pos': i+1,
             'user': s.User.Full_Name,
-            'logo': s.User.FavouriteTeam.Logo.url,
             'teamshort': s.User.FavouriteTeam.ShortName,
             'week': get_json_week_score(s.User, scoreweek, os.environ['PREDICTSEASON']),
             'seasonscore': s.SeasonScore,
@@ -561,7 +561,14 @@ def ScoreTableEnhancedView(request):
         'user': request.user.Full_Name
     }
 
+    jsonurls = {
+    }
+    
+    for team in Team.objects.all():
+        jsonurls[team.pk] = team.Logo.url
+
     context = {
+        'jsonurls': jsonurls,
         'jsonseasonscores': jsonseasonscores,
         'jsonweekscores': jsonweekscores,
         'jsonuser': jsonuser,


### PR DESCRIPTION
This PR fixes issue #96, whereby cached logo URLs become invalid after a few minutes and break the logo loading on the enhanced score table.