### PR TITLE
Changed SundayLive Task to 1700hrs

### DIFF
--- a/djangosite01/settings.py
+++ b/djangosite01/settings.py
@@ -232,7 +232,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     'Get Live Scores (Sun)': {
         'task': 'predictor.tasks.get_livescores',
-        'schedule': crontab(minute='*/1', hour='18-23', day_of_week=0),
+        'schedule': crontab(minute='*/1', hour='17-23', day_of_week=0),
     },
     'Get Live Scores (Mon AM)': {
         'task': 'predictor.tasks.get_livescores',


### PR DESCRIPTION
This PR moves the SundayLive scores pull task forward one hour to account for the UK clock change a week before the US