### PR TITLE
Status Check on API Read

### DIFF
--- a/predictor/tasks.py
+++ b/predictor/tasks.py
@@ -314,38 +314,41 @@ def fetch_results(fetchonly):
         results = []
 
         for game in rawjson['events']:
-            team1 = {}
-            team1['team'] = game['competitions'][0]['competitors'][0]['team']['abbreviation']
-            team1['score'] = int(game['competitions'][0]['competitors'][0]['score'])
-            team1['location'] = game['competitions'][0]['competitors'][0]['homeAway']
-            team2 = {}
-            team2['team'] = game['competitions'][0]['competitors'][1]['team']['abbreviation']
-            team2['score'] = int(game['competitions'][0]['competitors'][1]['score'])
-            team2['location'] = game['competitions'][0]['competitors'][1]['homeAway']
-            innerdict = {}
-            innerdict["Week"] = int(week)
-            innerdict["Season"] = int(season)
-            if team1['location'] == "home":
-                innerdict["HomeTeam"] = team1['team']
-                innerdict["AwayTeam"] = team2['team']
-                innerdict["HomeScore"] = team1['score']
-                innerdict["AwayScore"] = team2['score']
+            if game['status']['type']['completed'] != True:
+                pass
             else:
-                innerdict["HomeTeam"] = team2['team']
-                innerdict["AwayTeam"] = team1['team']
-                innerdict["HomeScore"] = team2['score']
-                innerdict["AwayScore"] = team1['score']
-            if team1['score'] == team2['score']:
-                innerdict["Winner"] = "Tie"
-            elif (team1['score']) > (team2['score']):
-                innerdict["Winner"] = "Home"
-            else:
-                innerdict["Winner"] = "Away"
-            outerdict = {}
-            outerdict["model"] = "predictor.results"
-            outerdict["pk"] = int(game['id'])
-            outerdict["fields"] = innerdict
-            results.append(outerdict)
+                team1 = {}
+                team1['team'] = game['competitions'][0]['competitors'][0]['team']['abbreviation']
+                team1['score'] = int(game['competitions'][0]['competitors'][0]['score'])
+                team1['location'] = game['competitions'][0]['competitors'][0]['homeAway']
+                team2 = {}
+                team2['team'] = game['competitions'][0]['competitors'][1]['team']['abbreviation']
+                team2['score'] = int(game['competitions'][0]['competitors'][1]['score'])
+                team2['location'] = game['competitions'][0]['competitors'][1]['homeAway']
+                innerdict = {}
+                innerdict["Week"] = int(week)
+                innerdict["Season"] = int(season)
+                if team1['location'] == "home":
+                    innerdict["HomeTeam"] = team1['team']
+                    innerdict["AwayTeam"] = team2['team']
+                    innerdict["HomeScore"] = team1['score']
+                    innerdict["AwayScore"] = team2['score']
+                else:
+                    innerdict["HomeTeam"] = team2['team']
+                    innerdict["AwayTeam"] = team1['team']
+                    innerdict["HomeScore"] = team2['score']
+                    innerdict["AwayScore"] = team1['score']
+                if team1['score'] == team2['score']:
+                    innerdict["Winner"] = "Tie"
+                elif (team1['score']) > (team2['score']):
+                    innerdict["Winner"] = "Home"
+                else:
+                    innerdict["Winner"] = "Away"
+                outerdict = {}
+                outerdict["model"] = "predictor.results"
+                outerdict["pk"] = int(game['id'])
+                outerdict["fields"] = innerdict
+                results.append(outerdict)
 
         # Removed old WSH/WAS & LA/LAR Logic as 'new' teams with
         # corresponding PKs will be added from 2021 season


### PR DESCRIPTION
This PR will ensure that games are completed before they are added the JSON export used to score Predictions.  This was added before the week 17 results import in the 2022/23 season in light of the Buffalo Bills/Cincinnati Bengals being postponed in the first quarter.  The API showed, at the time, the scores as they were at time of abandonment and so the script would have scored it as it stood.  This check will avoid this situation in future as any games without a Completed status of True will not be added to the results export.