### PR TITLE
Sunday Live Fixes

### DIFF
--- a/djangosite01/urls.py
+++ b/djangosite01/urls.py
@@ -3,6 +3,7 @@ from django.contrib.auth import views as auth_views
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from debug_toolbar.toolbar import debug_toolbar_urls
 
 urlpatterns = [
     path('accounts/', include('allauth.urls')),
@@ -19,3 +20,4 @@ urlpatterns = [
 ]
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns += debug_toolbar_urls()

--- a/predictor/tasks.py
+++ b/predictor/tasks.py
@@ -292,11 +292,10 @@ def populate_live_preseason_for_testing():
     for livegame in LiveGame.objects.all():
         livegame.delete()
     gamecount=0
-    for game in Match.objects.filter(Season=PigskinConfig.objects.get(Name="live").PredictSeason):
-        if game.DateTime.hour < 23:
-            newlive = LiveGame(Game=game.GameID, HomeTeam=game.HomeTeam.ShortName, AwayTeam=game.AwayTeam.ShortName, KickOff=game.DateTime.strftime("%H%M"), TeamIndex=teamdict[game.AwayTeam.ShortName], State=3)
-            newlive.save()
-            gamecount += 1
+    for game in Match.objects.filter(Season=PigskinConfig.objects.get(Name="live").PredictSeason, Week=PigskinConfig.objects.get(Name="live").PredictWeek):
+        newlive = LiveGame(Game=game.GameID, HomeTeam=game.HomeTeam.ShortName, AwayTeam=game.AwayTeam.ShortName, KickOff=game.DateTime.strftime("%H%M"), TeamIndex=teamdict[game.AwayTeam.ShortName], State=3)
+        newlive.save()
+        gamecount += 1
     print(str(gamecount)+" live games imported")
 
 @shared_task

--- a/predictor/templates/predictor/live-scores-test.html
+++ b/predictor/templates/predictor/live-scores-test.html
@@ -1,19 +1,19 @@
-<style>
-        body {
-          /* Set "my-sec-counter" to 0 */
-          counter-reset: my-sec-counter;
-        }
-        
-        .count::after {
-          /* Increment "my-sec-counter" by 1 */
-          counter-increment: my-sec-counter;
-          content: counter(my-sec-counter) ". ";
-        }
-        </style>
-
 {% extends "predictor/base.html" %}
 
 {% block content %}
+
+<style>
+    body {
+        /* Set "my-sec-counter" to 0 */
+        counter-reset: my-sec-counter;
+    }
+    
+    .count::after {
+        /* Increment "my-sec-counter" by 1 */
+        counter-increment: my-sec-counter;
+        content: counter(my-sec-counter) ". ";
+    }
+</style>
 <!--Vue JS-->
 <script src="https://cdn.jsdelivr.net/npm/vue@2.6.2/dist/vue.js"></script>
 <!--script src="https://cdn.jsdelivr.net/npm/vue@2.6.2"></script-->

--- a/predictor/templates/predictor/live-scores-test.html
+++ b/predictor/templates/predictor/live-scores-test.html
@@ -97,7 +97,7 @@
 
 <script>
     const getAPI = axios.create({
-        baseURL: apiroot.root,
+        baseURL: '/',
         timeout: 1000,
     })
 </script>

--- a/predictor/templates/predictor/live-scores.html
+++ b/predictor/templates/predictor/live-scores.html
@@ -1,3 +1,7 @@
+{% extends "predictor/base.html" %}
+
+{% block content %}
+
 <style>
     body {
       /* Set "my-sec-counter" to 0 */
@@ -9,11 +13,7 @@
       counter-increment: my-sec-counter;
       content: counter(my-sec-counter) ". ";
     }
-    </style>
-
-{% extends "predictor/base.html" %}
-
-{% block content %}
+</style>
 <!--Vue JS-->
 <script src="https://cdn.jsdelivr.net/npm/vue@2.6.2/dist/vue.js"></script>
 <!--script src="https://cdn.jsdelivr.net/npm/vue@2.6.2"></script-->

--- a/predictor/urls.py
+++ b/predictor/urls.py
@@ -68,9 +68,3 @@ urlpatterns = [
     path('live-scores-test/', LiveScoresTestView, name='live-scores-test'),
     re_path(r'^favicon', RedirectView.as_view(url='https://pigskinpredictor.s3.eu-west-2.amazonaws.com/static/favicon.ico')) #Favicon Redirect
 ]
-
-if settings.DEBUG:
-    import debug_toolbar
-    urlpatterns = [
-        path('__debug__/', include(debug_toolbar.urls)),
-    ] + urlpatterns

--- a/predictor/views.py
+++ b/predictor/views.py
@@ -5,6 +5,7 @@ from django.views.decorators.cache import cache_page
 from .helpers import get_json_week_score
 from django.shortcuts import render, get_object_or_404, redirect
 from accounts.forms import CustomUserChangeForm
+from django.conf import settings as djangosettings
 from django.utils import timezone
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.http import HttpResponse, JsonResponse
@@ -117,7 +118,7 @@ def ProfileView(request):
             else:
                 profileseason = PigskinConfig.objects.get(Name="live").PredictSeason
             if PigskinConfig.objects.get(Name="live").ResultsWeek < 19:
-                predweek = int(PigskinConfig.objects.get(Name="live").PredictSeason+PigskinConfig.objects.get(Name="live").ResultsWeek)
+                predweek = int(str(PigskinConfig.objects.get(Name="live").PredictSeason)+str(PigskinConfig.objects.get(Name="live").ResultsWeek))
                 try:
                     mypreds = Prediction.objects.filter(User=request.user, PredWeek=predweek)
                     if mypreds.count() > 0:
@@ -216,7 +217,7 @@ def ProfileNewPlayerView(request):
     else:    
         form = CustomUserChangeForm(instance=request.user)
         if PigskinConfig.objects.get(Name="live").ResultsWeek < 19:
-            predweek = int(PigskinConfig.objects.get(Name="live").PredictSeason+PigskinConfig.objects.get(Name="live").ResultsWeek)
+            predweek = int(str(PigskinConfig.objects.get(Name="live").PredictSeason)+str(PigskinConfig.objects.get(Name="live").ResultsWeek))
             try:
                 mypreds = Prediction.objects.filter(User=request.user, PredWeek=predweek)
                 if mypreds.count() > 0:
@@ -1284,15 +1285,15 @@ def LiveScoresView(request):
             'jsonuser': jsonuser,
             'week':scoreweek,
             'titleweek':PigskinConfig.objects.get(Name="live").ResultsWeek,
-            'title':'Live Scores'
+            'title':'Sunday Live'
         }
 
-        return render(request, 'predictor/live-scores.html', context, {'title':'Sunday Live'})
+        return render(request, 'predictor/live-scores.html', context)
     
 ### View to display live scores
 @require_GET
 def LiveScoresTestView(request):
-    if PigskinConfig.objects.get(Name="live").SundayLive == False:
+    if djangosettings.DEBUG == False:
         return redirect('home')
     else:
         # Below sets score week to 1 below current results week
@@ -1303,7 +1304,7 @@ def LiveScoresTestView(request):
             latest = Post.objects.all().first().pk
             return redirect('post-latest', latest)
         else:
-            scoreweek = int(PigskinConfig.objects.get(Name="live").PredictSeason+PigskinConfig.objects.get(Name="live").ResultsWeek)
+            scoreweek = int(str(PigskinConfig.objects.get(Name="live").PredictSeason)+str(PigskinConfig.objects.get(Name="live").ResultsWeek))
 
         jsonpredsforlive = cache.get('jsonpredsforlive')
 
@@ -1329,17 +1330,14 @@ def LiveScoresTestView(request):
             for i in userlist:
                 jsonpredsforlive[i.Full_Name]=[]
                 for a in Prediction.objects.filter(PredWeek=scoreweek, User=i).select_related('Game'):
-                    # Only add Sunday games to list
-                    if a.Game.DateTime.date() == datetime.date.today():
-                    # Test 'if' for Sunday week 1
-                    # if a.Game.DateTime.date() == datetime.datetime.fromisoformat('2021-09-12').date():   
-                        jsonpredsforlive[i.Full_Name].append({
-                        'game': a.Game.GameID,
-                        'winner': a.Winner,
-                        'banker': a.Banker,
-                        'joker': a.Joker,
-                        'pts': 0
-                        })
+                    # Remove today validation for test view
+                    jsonpredsforlive[i.Full_Name].append({
+                    'game': a.Game.GameID,
+                    'winner': a.Winner,
+                    'banker': a.Banker,
+                    'joker': a.Joker,
+                    'pts': 0
+                    })
             cache.set('jsonpredsforlive', jsonpredsforlive, CacheTTL_3Days)
 
         try:
@@ -1369,7 +1367,7 @@ def LiveScoresTestView(request):
             'jsonuser': jsonuser,
             'week':scoreweek,
             'titleweek':PigskinConfig.objects.get(Name="live").ResultsWeek,
-            'title':'Live Scores'
+            'title':'Sunday Live'
         }
 
-        return render(request, 'predictor/live-scores-test.html', context, {'title':'Sunday Live'})
+        return render(request, 'predictor/live-scores-test.html', context)


### PR DESCRIPTION
This PR fixes a few issues with the Sunday Live page following recent upgrades:  -

- Removes incorrect doc type from `render()` args to allow pages to load correctly;
- Corrects scoreweek calculation now that config has moved from `str` env vars to `int` db values;
- Fixes a template issue whereby <!DOCTYPE html> wasn't the first thing returned;
- Introduces some improvements to the Sunday Live Test page to allow for easier local testing
  - Removes some date check logic
  - Amends API Root for local running
  - Only grabs games for specified week