### PR TITLE
Highlight Bankers on Sunday Live

### DIFF
--- a/predictor/static/css/pigskin.css
+++ b/predictor/static/css/pigskin.css
@@ -43,6 +43,17 @@
   opacity: 70%;
 }
 
+.bankerlivetext {
+  border: solid 2px rgba(1, 89, 157, 0.20);
+  background-color: rgba(218, 165, 32, 0.5);
+  padding: 2px 5px 3px 5px;
+  border-radius: 10px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.6);
+  opacity: 70%;
+}
+
 .notchosenlivetext {
   font-weight: 400;
   font-size: 1.1rem;

--- a/predictor/templates/predictor/live-scores-test.html
+++ b/predictor/templates/predictor/live-scores-test.html
@@ -28,71 +28,75 @@
 
 <div class="container">
 <h5 class="mb-3">Sunday Live <span class = "superlowlight">|</span> week {{ titleweek }}</h5>
-    <div class="divider"></div>
-    <p><h6 class="tip">Tables update every 60 secs</h6></p>
-    <div class="row">
-        <div id="vue-table">
-            <div class="col m6 s12">
-                <table id="playerpoints" class="striped live-scores" aria-describedby="Live Sunday Scoretable">
-                <thead>
-                    <tr class="table-highlight striped table-top-pad">
-                        <td class = "stats-table-header col-100-l" colspan="2">Live Sunday Pts</td>
-                        <td class = "mobile-link"><a class="mobile-only" href="#livegames">Games</td>
-                    </tr>
-                    <tr class="table-secondary">
-                        <th class = "stats-header table-secondary-header pad-l table-right" colspan="2">Player</th>
-                        <th class = "stats-header table-secondary-header table-right">Pts</th>
-                    </tr>
-                </thead>
-                <tbody name ="livescores-score-table" is="transition-group">
-                <tr v-for="entry in sortedTable" :key="entry.User">
-                    <td v-if="entry.User ===  currentUser" class = "table-highlight enhanced clamp no-wrap vertical-centre pad-l"><img v-bind:src="entry.FavTeam | imgurl" :alt="entry.FavTeam" class="vertical-centre team_small"></img><span class="vertical-centre table-firstname"> &nbsp;[[entry.User | firstname]]</span><span class="table-secondname vertical-centre">[[entry.User | secondname]]</span><span> &nbsp;<span class=table-joker><i v-if="entry.Joker !== null" class="fas fa-check" v-bind:title="entry.Joker"></i></span></td>
-                    <td v-else class="enhanced clamp no-wrap pad-l"><img :src="entry.FavTeam | imgurl" :alt="entry.FavTeam" class="vertical-centre team_small"></img><span class="vertical-centre table-firstname"> &nbsp;[[entry.User | firstname]]</span><span class="table-secondname vertical-centre">[[entry.User | secondname]]</span> &nbsp;<span class=table-joker><i v-if="entry.Joker !== null" class="fas fa-check" v-bind:title="entry.Joker"></i></span></td>
-                    <td width="30px" v-if="entry.User ===  currentUser" class = "table-highlight enhanced clamp pad-l table-logo"></td>
-                    <td v-else td width="30px" class="enhanced clamp pad-l table-logo"></td>
-                    <td v-if="entry.User ===  currentUser" class="table-highlight"><span class="table-firstname">[[entry.Points]]</span></td>
-                    <td v-else><span class="table-firstname">[[entry.Points]]</span></td>
-                </tr>
-                </tbody>
-                </table>
-                <br>
-            </div>
-  
+<div class="divider"></div>
+<p><h6 class="tip">Tables update every 60 secs</h6></p>
+<div class="row">
+    <div id="vue-table">
         <div class="col m6 s12">
-            <table id="livegames" class="striped" aria-describedby="Live Sunday Games">
-                <thead>
-                    <tr class="table-highlight striped table-top-pad">
-                        <td class = "stats-table-header" colspan="3">Game Scores</td>
-                        <td class = "mobile-link table-left" colspan="2"><a class="mobile-only" href="#playerpoints">Points</td>
-                    </tr>
-                    <tr class="table-secondary">
-                        <th class = "stats-header table-secondary-header pad-l table-left" colspan="2">Away</th>
-                        <th class = "stats-header table-secondary-header table-center">Score</th>
-                        <th class = "stats-header table-secondary-header table-right" colspan="2">Home</th>
-                    </tr>
-                </thead>
-                <tbody name ="livegames-score-table" is="transition-group">
-                    <tr v-for="game in sortedScores" :key="game.Game" v-bind:class="[game.Updated ? updatedClass : stdClass]">
-                        <td v-bind:class="[tableLeftClass, game.State === 2 ? gameCompleteClass : '', predictedWinner(game.Game) == 'Away' ? selectedWinnerTextClass : notSelectedWinnerTextClass]">[[game.AwayTeam]]</td>
-                        <td v-bind:class="[tableLogoClass, game.State === 2 ? gameCompleteClass : '', predictedWinner(game.Game) == 'Away' ? selectedWinnerLogoClass : notSelectedWinnerLogoClass]"><img v-bind:src="game.AwayTeam | imgurl" :alt="game.AwayTeam" style="vertical-align:middle" class="team_small"></td>
-                        <td v-bind:class="[tableCenterClass, game.State === 2 ? gameCompleteClass : '']"><span v-bind:class="[predictedWinner(game.Game) == 'Away' ? selectedWinnerTextClass : notSelectedWinnerTextClass]">[[game.AwayScore]]</span> · <span v-bind:class="[predictedWinner(game.Game) == 'Home' ? selectedWinnerTextClass : notSelectedWinnerTextClass]">[[game.HomeScore]]</span></td>
-                        <td v-bind:class="[tableLogoClass, game.State === 2 ? gameCompleteClass : '', predictedWinner(game.Game) == 'Home' ? selectedWinnerLogoClass : notSelectedWinnerLogoClass]"><img v-bind:src="game.HomeTeam | imgurl" :alt="game.HomeTeam" style="vertical-align:middle" class="team_small"></td>
-                        <td v-bind:class="[tableRightClass, game.State === 2 ? gameCompleteClass : '', predictedWinner(game.Game) == 'Home' ? selectedWinnerTextClass : notSelectedWinnerTextClass]">[[game.HomeTeam]]</td>
-
-                    </tr>
-                </tbody>
+            <table id="playerpoints" class="striped live-scores" aria-describedby="Live Sunday Scoretable">
+            <thead>
+                <tr class="table-highlight striped table-top-pad">
+                    <td class = "stats-table-header col-100-l" colspan="2">Live Sunday Pts</td>
+                    <td class = "mobile-link"><a class="mobile-only" href="#livegames">Games</td>
+                </tr>
+                <tr class="table-secondary">
+                    <th class = "stats-header table-secondary-header pad-l table-right" colspan="2">Player</th>
+                    <th class = "stats-header table-secondary-header table-right">Pts</th>
+                </tr>
+            </thead>
+            <tbody name ="livescores-score-table" is="transition-group">
+            <tr v-for="entry in sortedTable" :key="entry.User">
+                <td v-if="entry.User ===  currentUser" class = "table-highlight enhanced clamp no-wrap vertical-centre pad-l"><img v-bind:src="entry.FavTeam | imgurl" :alt="entry.FavTeam" class="vertical-centre team_small"></img><span class="vertical-centre table-firstname"> &nbsp;[[entry.User | firstname]]</span><span class="table-secondname vertical-centre">[[entry.User | secondname]]</span><span> &nbsp;<span class=table-joker><i v-if="entry.Joker !== null" class="fas fa-check" v-bind:title="entry.Joker"></i></span></td>
+                <td v-else class="enhanced clamp no-wrap pad-l"><img :src="entry.FavTeam | imgurl" :alt="entry.FavTeam" class="vertical-centre team_small"></img><span class="vertical-centre table-firstname"> &nbsp;[[entry.User | firstname]]</span><span class="table-secondname vertical-centre">[[entry.User | secondname]]</span> &nbsp;<span class=table-joker><i v-if="entry.Joker !== null" class="fas fa-check" v-bind:title="entry.Joker"></i></span></td>
+                <td width="30px" v-if="entry.User ===  currentUser" class = "table-highlight enhanced clamp pad-l table-logo"></td>
+                <td v-else td width="30px" class="enhanced clamp pad-l table-logo"></td>
+                <td v-if="entry.User ===  currentUser" class="table-highlight"><span class="table-firstname">[[entry.Points]]</span></td>
+                <td v-else><span class="table-firstname">[[entry.Points]]</span></td>
+            </tr>
+            </tbody>
             </table>
+            <br>
         </div>
-        </div>
-        </div>
+
+    <div class="col m6 s12">
+        <table id="livegames" class="striped" aria-describedby="Live Sunday Games">
+            <thead>
+                <tr class="table-highlight striped table-top-pad">
+                    <td class = "stats-table-header" colspan="3">Game Scores</td>
+                    <td class = "mobile-link table-left" colspan="2"><a class="mobile-only" href="#playerpoints">Points</td>
+                </tr>
+                <tr class="table-secondary">
+                    <th class = "stats-header table-secondary-header pad-l table-left" colspan="2">Away</th>
+                    <th class = "stats-header table-secondary-header table-center">Score</th>
+                    <th class = "stats-header table-secondary-header table-right" colspan="2">Home</th>
+                </tr>
+            </thead>
+            <tbody name ="livegames-score-table" is="transition-group">
+                <tr v-for="game in liveScores" :key="game.Game" v-bind:class="[game.Updated ? updatedClass : stdClass]">
+                    <!-- Away Team Name -->
+                    <td v-bind:class="[tableLeftClass, game.State === 2 ? gameCompleteClass : '']"><span v-bind:class = "[isBanker(game.Game) == true ? bankerClass : predictedWinner(game.Game) == 'Away' ? selectedWinnerTextClass : notSelectedWinnerTextClass]">[[game.AwayTeam]]</span></td>
+                    <!-- Away Team Logo -->
+                    <td v-bind:class="[tableLogoClass, game.State === 2 ? gameCompleteClass : '', predictedWinner(game.Game) == 'Away' ? selectedWinnerLogoClass : notSelectedWinnerLogoClass]"><img v-bind:src="game.AwayTeam | imgurl" :alt="game.AwayTeam" style="vertical-align:middle" class="team_small"></td>
+                    <!-- Score -->
+                    <td v-bind:class="[tableCenterClass, game.State === 2 ? gameCompleteClass : '', game.Winning === predictedWinner(game.Game) ? liveScoreCorrectClass : liveScoreIncorrectClass ]">[[game.AwayScore]] · [[game.HomeScore]]</td>
+                    <!-- Home Team Logo -->
+                    <td v-bind:class="[tableLogoClass, game.State === 2 ? gameCompleteClass : '', predictedWinner(game.Game) == 'Home' ? selectedWinnerLogoClass : notSelectedWinnerLogoClass]"><img v-bind:src="game.HomeTeam | imgurl" :alt="game.HomeTeam" style="vertical-align:middle" class="team_small"></td>
+                    <!-- Home Team Name -->
+                    <td v-bind:class="[tableRightClass, game.State === 2 ? gameCompleteClass : '']"><span v-bind:class = "[predictedWinner(game.Game) == 'Home' ? selectedWinnerTextClass : notSelectedWinnerTextClass]">[[game.HomeTeam]]</span></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    </div>
+    </div>
 
 <script>
-    let preds = JSON.parse(document.getElementById('preds').textContent);
-    let apiroot = JSON.parse(document.getElementById('apiroot').textContent);
-    let points = JSON.parse(document.getElementById('points').textContent);
-    let currentUser = JSON.parse(document.getElementById('currentuser').textContent).user;
-    let logoUrls = JSON.parse(document.getElementById('logo_urls').textContent);
-    let liveScores = []
+let preds = JSON.parse(document.getElementById('preds').textContent);
+let apiroot = JSON.parse(document.getElementById('apiroot').textContent);
+let points = JSON.parse(document.getElementById('points').textContent);
+let currentUser = JSON.parse(document.getElementById('currentuser').textContent).user;
+let logoUrls = JSON.parse(document.getElementById('logo_urls').textContent);
+let liveScores = []
 </script>
 
 <script>
@@ -114,6 +118,7 @@
             tableRightClass: "table-right",
             tableLogoClass: "table-logo",
             gameCompleteClass: "livegame-complete",
+            bankerClass: "bankerlivetext",
             selectedWinnerLogoClass: "chosenlivelogo",
             notSelectedWinnerLogoClass: "notchosenlivelogo",
             selectedWinnerTextClass: "chosenlivetext",
@@ -187,6 +192,9 @@
             },
             predictedWinner(gameid) { 
                 return this.preds[currentUser].find(obj => obj.game === gameid).winner
+            },
+            isBanker(gameid) { 
+                return this.preds[currentUser].find(obj => obj.game === gameid).banker
             },
             updateTotals() {
                 // Below will iterate through each user's pred pts and amend their total points for the live table

--- a/predictor/templates/predictor/live-scores.html
+++ b/predictor/templates/predictor/live-scores.html
@@ -74,7 +74,7 @@
             <tbody name ="livegames-score-table" is="transition-group">
                 <tr v-for="game in liveScores" :key="game.Game" v-bind:class="[game.Updated ? updatedClass : stdClass]">
                     <!-- Away Team Name -->
-                    <td v-bind:class="[tableLeftClass, game.State === 2 ? gameCompleteClass : '']"><span v-bind:class = "[predictedWinner(game.Game) == 'Away' ? selectedWinnerTextClass : notSelectedWinnerTextClass]">[[game.AwayTeam]]</span></td>
+                    <td v-bind:class="[tableLeftClass, game.State === 2 ? gameCompleteClass : '']"><span v-bind:class = "[isBanker(game.Game) == true ? bankerClass : predictedWinner(game.Game) == 'Away' ? selectedWinnerTextClass : notSelectedWinnerTextClass]">[[game.AwayTeam]]</span></td>
                     <!-- Away Team Logo -->
                     <td v-bind:class="[tableLogoClass, game.State === 2 ? gameCompleteClass : '', predictedWinner(game.Game) == 'Away' ? selectedWinnerLogoClass : notSelectedWinnerLogoClass]"><img v-bind:src="game.AwayTeam | imgurl" :alt="game.AwayTeam" style="vertical-align:middle" class="team_small"></td>
                     <!-- Score -->
@@ -118,6 +118,7 @@ var app = new Vue({
         tableRightClass: "table-right",
         tableLogoClass: "table-logo",
         gameCompleteClass: "livegame-complete",
+        bankerClass: "bankerlivetext",
         selectedWinnerLogoClass: "chosenlivelogo",
         notSelectedWinnerLogoClass: "notchosenlivelogo",
         selectedWinnerTextClass: "chosenlivetext",
@@ -193,6 +194,9 @@ var app = new Vue({
         },
         predictedWinner(gameid) { 
             return this.preds[currentUser].find(obj => obj.game === gameid).winner
+        },
+        isBanker(gameid) { 
+            return this.preds[currentUser].find(obj => obj.game === gameid).banker
         },
         updateTotals() {
             // Below will iterate through each user's pred pts and amend their total points for the live table


### PR DESCRIPTION
After feedback following the 2024 season, this PR will highlight bankers on the Sunday Live page - it does this by adding a higher priority check on the ternary logic on the Vue bind against the span element of the table which shows the road team name.  The new style is the same as the other, non-banker, style except that it is filled in with gold.

Addresses issue #235 