### PR TITLE
GHA: S3 Upload Source Paths Updated

### DIFF
--- a/.github/workflows/Static_File_Uploads_Dev.yaml
+++ b/.github/workflows/Static_File_Uploads_Dev.yaml
@@ -17,5 +17,5 @@ jobs:
         AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_DEV }}
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_DEV }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY_DEV }}
-        SOURCE_DIR: 'predictor/static/predictor'
+        SOURCE_DIR: 'predictor/static'
         DEST_DIR: 'static/predictor'

--- a/.github/workflows/Static_File_Uploads_Master.yaml
+++ b/.github/workflows/Static_File_Uploads_Master.yaml
@@ -17,5 +17,5 @@ jobs:
         AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_PROD }}
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_PROD }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY_PROD }}
-        SOURCE_DIR: 'predictor/static/predictor'
+        SOURCE_DIR: 'predictor/static'
         DEST_DIR: 'static/predictor'


### PR DESCRIPTION
Small PR to amend the GitHub Actions used to upload static files to S3 storage on commit to main branch, following a move of the static files as part of 2025 improvements.