### PR TITLE
New Banker Flag Check Function

### DIFF
--- a/djangosite01/settings.py
+++ b/djangosite01/settings.py
@@ -305,6 +305,10 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute=00, hour=21, day_of_week=4),
         'args': [ 'predict' ]
     },
+    'Check Banker Flags': {
+      'task': 'predictor.tasks.banker_flag_confirmation',
+      'schedule': crontab(minute=05, hour=21, day_of_week=4)
+    },
     'Update Results Week': {
         'task': 'predictor.tasks.update_week',
         'schedule': crontab(minute=00, hour=8, day_of_week=3),


### PR DESCRIPTION
This PR addresses GitHub issue #243.

It adds a new weekly job, at 21:05 London time on a Thursday, to check each banker for the week and amend any matching Predictions which don't have the banker flag set correctly. It will then report output to Celery logs and raise an error in Sentry if this occurs again.