### PR TITLE
5pm week live games

### DIFF
--- a/djangosite01/settings.py
+++ b/djangosite01/settings.py
@@ -280,7 +280,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     'Get Live Scores (Sun)': {
         'task': 'predictor.tasks.get_livescores',
-        'schedule': crontab(minute='*/1', hour='18-23', day_of_week=0),
+        'schedule': crontab(minute='*/1', hour='17-23', day_of_week=0),
     },
     'Get Live Scores (Mon AM)': {
         'task': 'predictor.tasks.get_livescores',

--- a/predictor/tasks.py
+++ b/predictor/tasks.py
@@ -243,9 +243,8 @@ def get_livescores():
     # Will run at 5pm every week but only needs to run at 5pm one week of the year
     # when the UK clock changes go back in the last week of October (US goers back first Sunday of November)
     if dt.now().hour == 17:
-        if dt.now().month == 10 and dt.now().day > 24:
-            
-
+        if not (dt.now().month == 10 and dt.now().day > 24):
+            return
     for livegame in LiveGame.objects.all():
         try:
             url = f"http://site.api.espn.com/apis/site/v2/sports/football/nfl/summary?event={livegame.Game}"


### PR DESCRIPTION
Fixes issue #246 by amending the schedule top add an extra hour, but also adds a date check so that we don't annoy the ESPN API by polling every minute before kick-off - so the scheduled job will run every minute from 5pm but only poll ESPN if it is not Oct 25th onwards.